### PR TITLE
Update readme to specify blender version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # glTF2 blender importer
 
-This blender addon is in an early development stage.  
+This blender addon is in an early development stage. It requires blender version 2.79 or higher.
 You will find some bugs, code may need some big refactoring.  
 Feel free to contribute :)  
 Current version may not fully follow glTF2 specification. This will change in near future ;-)

--- a/io_scene_gltf2_importer/__init__.py
+++ b/io_scene_gltf2_importer/__init__.py
@@ -29,11 +29,11 @@ from .io import *
 from .scene import *
 
 bl_info = {
-    "name": "Blender glTF2 importer",
+    "name": "glTF2 importer",
     "version": (0, 0, 1),
     "author": "Julien Duroure",
     "blender": (2, 79, 0),
-    "description": "Blender glTF2 importer",
+    "description": "glTF2 importer",
     "location": "File > Import",
     "category": "Import-Export"
 }


### PR DESCRIPTION
Remove redundant "blender" from addon description- since we're already in blender theres no point repeating the word in the addon description, just confuses when sorting the plugin names alphabetically. 